### PR TITLE
Discard comments in last processing step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- Discard comments in last, allowing to use comments such as `/* autoprefixer: off */` ([#2](https://github.com/Shopify/postcss-shopify/pull/2))
+- Discard comments in the last processing step, allowing to use comments such as `/* autoprefixer: off */` ([#2](https://github.com/Shopify/postcss-shopify/pull/2))
 
 ## 1.0.0 - 2017-03-05
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Discard comments in last, allowing to use comments such as `/* autoprefixer: off */` ([#2](https://github.com/Shopify/postcss-shopify/pull/2))
 
-## [1.0.0] - 2017-03-05
+## 1.0.0 - 2017-03-05
 - Initial release
+
+[Unreleased]: https://github.com/Shopify/postcss-shopify/compare/v1.0.0...master

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+  node:
+    version: 6.11.5
 
 dependencies:
   override:

--- a/features.js
+++ b/features.js
@@ -1,8 +1,8 @@
 module.exports = {
-  discardComments: (options) => require('postcss-discard-comments')(options),
   calc: (options) => require('postcss-calc')(options),
   flexbugsFixes: () => require('postcss-flexbugs-fixes'),
   selectorMatches: () => require('postcss-selector-matches'),
   willChange: () => require('postcss-will-change'),
   autoprefixer: (options) => require('autoprefixer')(options),
+  discardComments: (options) => require('postcss-discard-comments')(options),
 };


### PR DESCRIPTION
This allows using comments such as `/* autoprefixer: off */` in the codebase.

Fixes an issue where comments would get stripped too early, and those `/* autoprefixer: off */` comments wouldn't appear at the time of the autoprefixer step.