### PR TITLE
Remove mergeLonghand plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,17 @@ const plugin = postcss.plugin('postcss-shopify', (options = {}) => {
 
   if (options.minimize) {
     processor.use(require('cssnano')({
-      preset: 'default',
+      preset: ['default', {
+        // This rule has an issue where multiple declarations
+        // for the same property are merged into one, which can
+        // change the semantics of code like:
+        //
+        // .klass {
+        //   padding-left: 4rem;
+        //   padding-left: calc(4rem + event(safe-area-inset-left));
+        // }
+        mergeLonghand: false,
+      }],
     }));
   }
 


### PR DESCRIPTION
Per https://github.com/cssnano/cssnano/issues/663, there are issues with the merge-longhand plugin and declarations that use multiple, identical longhand properties to get fallbacks for missing features.